### PR TITLE
Have better disabling of nrpe and nsca

### DIFF
--- a/handlers/nrpe.yml
+++ b/handlers/nrpe.yml
@@ -6,22 +6,26 @@
     name: "{{ bsd_nrpe_service }}"
     state: started
     enabled: true
+  when: bsd_nrpe_enable|bool
 
 - name: disable and stop nrpe
   ansible.builtin.service:
     name: "{{ bsd_nrpe_service }}"
     state: stopped
     enabled: false
+  when: bsd_nrpe_enable|bool
 
 - name: start nrpe
   ansible.builtin.service:
     name: "{{ bsd_nrpe_service }}"
     state: started
+  when: bsd_nrpe_enable|bool
 
 - name: stop nrpe
   ansible.builtin.service:
     name: "{{ bsd_nrpe_service }}"
     state: stopped
+  when: bsd_nrpe_enable|bool
 
 - name: restart nrpe
   ansible.builtin.service:

--- a/handlers/nsca.yml
+++ b/handlers/nsca.yml
@@ -6,22 +6,26 @@
     name: "{{ bsd_nsca_service }}"
     state: started
     enabled: true
+  when: bsd_nsca_enable|bool
 
 - name: disable and stop nsca
   ansible.builtin.service:
     name: "{{ bsd_nsca_service }}"
     state: stopped
     enabled: false
+  when: bsd_nsca_enable|bool
 
 - name: start nsca
   ansible.builtin.service:
     name: "{{ bsd_nsca_service }}"
     state: started
+  when: bsd_nsca_enable|bool
 
 - name: stop nsca
   ansible.builtin.service:
     name: "{{ bsd_nsca_service }}"
     state: stopped
+  when: bsd_nsca_enable|bool
 
 - name: restart nsca
   ansible.builtin.service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,10 +17,12 @@
 
 - name: Import nsca.yml
   ansible.builtin.import_tasks: nsca.yml
+  when: bsd_nsca_conf_recreate|bool
   tags: bsd_nagios_nsca
 
 - name: Import nrpe.yml
   ansible.builtin.import_tasks: nrpe.yml
+  when: bsd_nrpe_conf_recreate|bool
   tags: bsd_nagios_nrpe
 
 - name: Import rcconf.yml

--- a/tasks/rcconf.yml
+++ b/tasks/rcconf.yml
@@ -5,9 +5,11 @@
 
 - name: Import rcconf/nsca.yml
   ansible.builtin.import_tasks: rcconf/nsca.yml
+  when: bsd_nsca_conf_recreate|bool
 
 - name: Import rcconf/nrpe.yml
   ansible.builtin.import_tasks: rcconf/nrpe.yml
+  when: bsd_nrpe_conf_recreate|bool
 
 # EOF
 ...


### PR DESCRIPTION
Add some flexibility here, in my environment I don't run nsca and nrpe on the nagios master is managed by ansible-role-nrpe (like all other machines).  These fixes are used to just disable both those functions here.